### PR TITLE
fix: allow npm publish in CI environment

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
         "version:patch": "npm version patch",
         "version:minor": "npm version minor",
         "version:major": "npm version major",
-        "prepublishOnly": "echo '❌ Use GitHub Actions for publishing! Run: git push origin main' && exit 1"
+        "prepublishOnly": "node -e \"if (!process.env.CI) { console.log('❌ Use GitHub Actions for publishing! Run: git push origin main'); process.exit(1); }\""
     },
     "keywords": [
         "ssh",


### PR DESCRIPTION
- Modify prepublishOnly script to allow publishing in CI
- Prevent local publishing while allowing GitHub Actions
- Fix automated release workflow