### PR TITLE
Feat: Adds auto-command execution to SSH connections

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -2,6 +2,7 @@ import inquirer from 'inquirer';
 import chalk from 'chalk';
 import { existsSync } from 'fs';
 import { addHost, loadConfig } from '../utils/config.js';
+import { displayHostInfo } from '../utils/display.js';
 import type { SSHHost } from '../types/ssh.js';
 
 export async function addCommand() {
@@ -117,24 +118,24 @@ export async function addCommand() {
         {
             type: 'confirm',
             name: 'hasAutoCommands',
-            message: '접속 후 자동으로 실행할 명령어를 설정하시겠습니까?',
+            message: 'Do you want to configure auto-run commands after connection?',
             default: false,
         },
         {
             type: 'editor',
             name: 'autoCommandsInput',
-            message: '자동 실행할 명령어들을 입력하세요 (한 줄에 하나씩):',
+            message: 'Enter commands to run automatically (one per line):',
             when: answers => answers.hasAutoCommands,
             validate: (input: string) => {
                 if (!input || !input.trim()) {
-                    return '최소 하나의 명령어를 입력해주세요.';
+                    return 'Please enter at least one command.';
                 }
                 return true;
             },
         },
     ]);
 
-    // 자동 명령어 처리
+    // Process auto commands
     let autoCommands: string[] | undefined = undefined;
     if (answers.hasAutoCommands && answers.autoCommandsInput) {
         autoCommands = answers.autoCommandsInput
@@ -160,27 +161,7 @@ export async function addCommand() {
 
         console.log();
         console.log(chalk.green('✅ Host added successfully!'));
-        console.log();
-        console.log(chalk.blue('📋 Host information:'));
-        console.log(`   ${chalk.cyan('Name:')} ${newHost.name}`);
-        console.log(`   ${chalk.cyan('Address:')} ${newHost.user}@${newHost.host}:${newHost.port}`);
-        if (newHost.keyPath) {
-            console.log(`   ${chalk.cyan('Key file:')} ${newHost.keyPath}`);
-        }
-        if (newHost.description) {
-            console.log(`   ${chalk.cyan('Description:')} ${newHost.description}`);
-        }
-        if (newHost.tags && newHost.tags.length > 0) {
-            console.log(`   ${chalk.cyan('Tags:')} ${newHost.tags.join(', ')}`);
-        }
-        if (newHost.autoCommands && newHost.autoCommands.length > 0) {
-            console.log(`   ${chalk.cyan('자동 명령어:')} ${newHost.autoCommands.length}개`);
-            newHost.autoCommands.forEach((cmd, index) => {
-                console.log(`     ${chalk.dim(`${index + 1}.`)} ${chalk.yellow(cmd)}`);
-            });
-        }
-        console.log();
-        console.log(chalk.blue('💡 To connect:'), chalk.gray(`simple-ssh connect ${newHost.name}`));
+        displayHostInfo(newHost);
     } catch (error) {
         console.log(chalk.red('❌ Error adding host:'), error);
     }

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -114,7 +114,34 @@ export async function addCommand() {
                     .filter(tag => tag.length > 0);
             },
         },
+        {
+            type: 'confirm',
+            name: 'hasAutoCommands',
+            message: '접속 후 자동으로 실행할 명령어를 설정하시겠습니까?',
+            default: false,
+        },
+        {
+            type: 'editor',
+            name: 'autoCommandsInput',
+            message: '자동 실행할 명령어들을 입력하세요 (한 줄에 하나씩):',
+            when: answers => answers.hasAutoCommands,
+            validate: (input: string) => {
+                if (!input || !input.trim()) {
+                    return '최소 하나의 명령어를 입력해주세요.';
+                }
+                return true;
+            },
+        },
     ]);
+
+    // 자동 명령어 처리
+    let autoCommands: string[] | undefined = undefined;
+    if (answers.hasAutoCommands && answers.autoCommandsInput) {
+        autoCommands = answers.autoCommandsInput
+            .split('\n')
+            .map((cmd: string) => cmd.trim())
+            .filter((cmd: string) => cmd.length > 0);
+    }
 
     const newHost: SSHHost = {
         name: answers.name,
@@ -123,6 +150,7 @@ export async function addCommand() {
         port: answers.port,
         keyPath: answers.authMethod === 'key' ? answers.keyPath : undefined,
         usePassword: answers.authMethod === 'password',
+        autoCommands: autoCommands,
         description: answers.description,
         tags: answers.tags,
     };
@@ -144,6 +172,12 @@ export async function addCommand() {
         }
         if (newHost.tags && newHost.tags.length > 0) {
             console.log(`   ${chalk.cyan('Tags:')} ${newHost.tags.join(', ')}`);
+        }
+        if (newHost.autoCommands && newHost.autoCommands.length > 0) {
+            console.log(`   ${chalk.cyan('자동 명령어:')} ${newHost.autoCommands.length}개`);
+            newHost.autoCommands.forEach((cmd, index) => {
+                console.log(`     ${chalk.dim(`${index + 1}.`)} ${chalk.yellow(cmd)}`);
+            });
         }
         console.log();
         console.log(chalk.blue('💡 To connect:'), chalk.gray(`simple-ssh connect ${newHost.name}`));

--- a/packages/cli/src/commands/connect.ts
+++ b/packages/cli/src/commands/connect.ts
@@ -53,9 +53,28 @@ export async function connectCommand(hostName?: string, options: ConnectionOptio
     console.log(chalk.gray(`   ${user}@${targetHost.host}:${port}`));
 
     const spinner = ora('Attempting SSH connection...').start();
+     const sshArgs = ['-p', port.toString()];
+     // SSH 명령어 구성
 
     // Build SSH command
     const sshArgs = ['-p', port.toString(), `${user}@${targetHost.host}`];
+     // 자동 명령어가 있는지 확인
+     const hasAutoCommands = targetHost.autoCommands && targetHost.autoCommands.length > 0;
+     
+     if (hasAutoCommands) {
+         console.log(chalk.blue(`🤖 자동 명령어 ${targetHost.autoCommands!.length}개가 설정되어 있습니다:`));
+         targetHost.autoCommands!.forEach((cmd, index) => {
+             console.log(`   ${chalk.dim(`${index + 1}.`)} ${chalk.yellow(cmd)}`);
+         });
+         console.log();
+         
+         // 자동 명령어들을 세미콜론으로 연결하고 마지막에 bash 추가 (대화형 세션 유지)
+         const commandString = targetHost.autoCommands!.join('; ') + '; bash';
+         sshArgs.push(`${user}@${targetHost.host}`, commandString);
+     } else {
+         // 일반 대화형 연결
+         sshArgs.push(`${user}@${targetHost.host}`);
+     }
 
     // Add key file if specified
     if (targetHost.keyPath) {

--- a/packages/cli/src/commands/connect.ts
+++ b/packages/cli/src/commands/connect.ts
@@ -54,10 +54,16 @@ export async function connectCommand(hostName?: string, options: ConnectionOptio
     console.log(chalk.blue(`🔗 Connecting to ${targetHost.name}...`));
     console.log(chalk.gray(`   ${user}@${targetHost.host}:${port}`));
 
+    // SSH 명령어 구성
+    const sshArgs = ['-p', port.toString()];
     const spinner = ora('Attempting SSH connection...').start();
      const sshArgs = ['-p', port.toString()];
      // SSH 명령어 구성
 
+    // 키 파일이 있으면 추가
+    if (targetHost.keyPath) {
+        sshArgs.unshift('-i', targetHost.keyPath);
+    }
     // Build SSH command
     const sshArgs = ['-p', port.toString(), `${user}@${targetHost.host}`];
      // 자동 명령어가 있는지 확인
@@ -78,11 +84,35 @@ export async function connectCommand(hostName?: string, options: ConnectionOptio
          sshArgs.push(`${user}@${targetHost.host}`);
      }
 
+    // 자동 명령어가 있는지 확인
+    const hasAutoCommands = targetHost.autoCommands && targetHost.autoCommands.length > 0;
     // Add key file if specified
     if (targetHost.keyPath) {
         sshArgs.unshift('-i', targetHost.keyPath);
     }
 
+    if (hasAutoCommands) {
+        console.log(chalk.blue(`🤖 자동 명령어 ${targetHost.autoCommands!.length}개가 설정되어 있습니다:`));
+        targetHost.autoCommands!.forEach((cmd, index) => {
+            console.log(`   ${chalk.dim(`${index + 1}.`)} ${chalk.yellow(cmd)}`);
+        });
+        console.log();
+
+        // 자동 명령어만 실행 (대화형 세션은 별도로)
+        const commandString = targetHost.autoCommands!.join(' && ');
+        sshArgs.push(`${user}@${targetHost.host}`, commandString);
+    } else {
+        // 일반 대화형 연결
+        sshArgs.push(`${user}@${targetHost.host}`);
+    }
+
+    // 비밀번호 사용 시 대화형 모드 강제
+    if (targetHost.usePassword) {
+        console.log(chalk.yellow('💡 비밀번호를 사용하는 호스트입니다. 연결 후 비밀번호를 입력해주세요.'));
+    }
+
+    console.log(chalk.green(`✅ SSH 연결을 시작합니다...`));
+    console.log(chalk.gray(`실행 명령어: ssh ${sshArgs.join(' ')}`));
     // Show password prompt info
     if (targetHost.usePassword) {
         console.log(chalk.yellow('💡 This host uses password authentication. Please enter password when prompted.'));

--- a/packages/cli/src/commands/connect.ts
+++ b/packages/cli/src/commands/connect.ts
@@ -20,6 +20,8 @@ export async function connectCommand(hostName?: string, options: ConnectionOptio
     } else {
         // Host selection
         if (config.hosts.length === 0) {
+            console.log(chalk.yellow('⚠️  저장된 호스트가 없습니다.'));
+            console.log(chalk.blue('💡 먼저 호스트를 추가해보세요: simple-ssh add'));
             console.log(chalk.yellow('⚠️  No saved hosts found.'));
             console.log(chalk.blue('💡 Add a host first: simple-ssh add'));
             return;

--- a/packages/cli/src/commands/edit.ts
+++ b/packages/cli/src/commands/edit.ts
@@ -173,7 +173,29 @@ export async function editCommand(hostName?: string) {
                     .filter(tag => tag.length > 0);
             },
         },
+        {
+            type: 'confirm',
+            name: 'hasAutoCommands',
+            message: '자동 실행 명령어를 수정하시겠습니까?',
+            default: !!(targetHost.autoCommands && targetHost.autoCommands.length > 0),
+        },
+        {
+            type: 'editor',
+            name: 'autoCommandsInput',
+            message: '자동 실행할 명령어들을 입력하세요 (한 줄에 하나씩):',
+            default: targetHost.autoCommands ? targetHost.autoCommands.join('\n') : '',
+            when: answers => answers.hasAutoCommands,
+        },
     ]);
+
+    // 자동 명령어 처리
+    let autoCommands: string[] | undefined = undefined;
+    if (answers.hasAutoCommands && answers.autoCommandsInput) {
+        autoCommands = answers.autoCommandsInput
+            .split('\n')
+            .map((cmd: string) => cmd.trim())
+            .filter((cmd: string) => cmd.length > 0);
+    }
 
     const updatedHost: SSHHost = {
         name: answers.name,
@@ -182,6 +204,7 @@ export async function editCommand(hostName?: string) {
         port: answers.port,
         keyPath: answers.authMethod === 'key' ? answers.keyPath : undefined,
         usePassword: answers.authMethod === 'password',
+        autoCommands: autoCommands,
         description: answers.description,
         tags: answers.tags,
     };
@@ -202,6 +225,12 @@ export async function editCommand(hostName?: string) {
         }
         if (updatedHost.tags && updatedHost.tags.length > 0) {
             console.log(`   ${chalk.cyan('Tags:')} ${updatedHost.tags.join(', ')}`);
+        }
+        if (updatedHost.autoCommands && updatedHost.autoCommands.length > 0) {
+            console.log(`   ${chalk.cyan('자동 명령어:')} ${updatedHost.autoCommands.length}개`);
+            updatedHost.autoCommands.forEach((cmd, index) => {
+                console.log(`     ${chalk.dim(`${index + 1}.`)} ${chalk.yellow(cmd)}`);
+            });
         }
         console.log();
         console.log(chalk.blue('💡 To connect:'), chalk.gray(`simple-ssh connect ${updatedHost.name}`));

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -28,6 +28,9 @@ export async function listCommand() {
         } else {
             console.log(`   ${chalk.dim('🔧 Auth:')} ${chalk.gray('Default SSH settings')}`);
         }
+    if (host.autoCommands && host.autoCommands.length > 0) {
+      console.log(`   ${chalk.dim('🤖 자동 명령어:')} ${chalk.magenta(`${host.autoCommands.length}개`)}`);
+    }
     });
 
     console.log();

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -28,9 +28,9 @@ export async function listCommand() {
         } else {
             console.log(`   ${chalk.dim('🔧 Auth:')} ${chalk.gray('Default SSH settings')}`);
         }
-    if (host.autoCommands && host.autoCommands.length > 0) {
-      console.log(`   ${chalk.dim('🤖 자동 명령어:')} ${chalk.magenta(`${host.autoCommands.length}개`)}`);
-    }
+        if (host.autoCommands && host.autoCommands.length > 0) {
+            console.log(`   ${chalk.dim('🤖 Auto commands:')} ${chalk.magenta(`${host.autoCommands.length} command(s)`)}`);
+        }
     });
 
     console.log();

--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -1,6 +1,7 @@
 import inquirer from 'inquirer';
 import chalk from 'chalk';
 import { loadConfig, removeHost, getHost } from '../utils/config.js';
+import { createHostChoices } from '../utils/display.js';
 
 export async function removeCommand(hostName?: string) {
     const config = await loadConfig();
@@ -20,10 +21,7 @@ export async function removeCommand(hostName?: string) {
                 name: 'selectedHost',
                 message: 'Select host to remove:',
                 choices: [
-                    ...config.hosts.map(host => ({
-                        name: `${chalk.cyan(host.name)} - ${host.user}@${host.host}:${host.port}`,
-                        value: host.name,
-                    })),
+                    ...createHostChoices(config.hosts),
                     new inquirer.Separator(),
                     {
                         name: chalk.gray('Cancel'),
@@ -66,13 +64,13 @@ export async function removeCommand(hostName?: string) {
         {
             type: 'confirm',
             name: 'confirmed',
-            message: '정말로 삭제하시겠습니까?',
+            message: 'Are you sure you want to delete this host?',
             default: false,
         },
     ]);
 
     if (!confirmed) {
-        console.log(chalk.blue('취소되었습니다.'));
+        console.log(chalk.blue('Cancelled.'));
         return;
     }
 
@@ -80,11 +78,11 @@ export async function removeCommand(hostName?: string) {
         const success = await removeHost(targetHostName);
 
         if (success) {
-            console.log(chalk.green(`✅ 호스트 '${targetHostName}'이 성공적으로 삭제되었습니다.`));
+            console.log(chalk.green(`✅ Host '${targetHostName}' has been successfully removed.`));
         } else {
-            console.log(chalk.red(`❌ 호스트 '${targetHostName}' 삭제에 실패했습니다.`));
+            console.log(chalk.red(`❌ Failed to remove host '${targetHostName}'.`));
         }
     } catch (error) {
-        console.log(chalk.red('❌ 호스트 삭제 중 오류가 발생했습니다:'), error);
+        console.log(chalk.red('❌ Error occurred while removing host:'), error);
     }
 }

--- a/packages/cli/src/types/ssh.ts
+++ b/packages/cli/src/types/ssh.ts
@@ -4,8 +4,8 @@ export interface SSHHost {
     user: string;
     port: number;
     keyPath?: string;
-    usePassword?: boolean; // 비밀번호 사용 여부 (연결 시 입력받음)
-    autoCommands?: string[]; // 접속 후 자동 실행할 명령어들
+    usePassword?: boolean; // Whether to use password (prompted on connection)
+    autoCommands?: string[]; // Commands to run automatically after connection
     description?: string;
     tags?: string[];
 }

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 import { homedir } from 'os';
 import type { SSHConfig, SSHHost } from '../types/ssh.js';
 
-// 테스트 환경에서 HOME 환경변수를 우선 사용
+// Use HOME environment variable first for test environments
 function getHomeDir(): string {
     return process.env.HOME || process.env.USERPROFILE || homedir();
 }
@@ -43,14 +43,14 @@ export async function loadConfig(): Promise<SSHConfig> {
         const content = await readFile(configFile, 'utf-8');
         const config = JSON.parse(content) as SSHConfig;
 
-        // 기본값 병합
+        // Merge default values
         return {
             ...DEFAULT_CONFIG,
             ...config,
             hosts: config.hosts || [],
         };
     } catch (error) {
-        console.error('설정 파일을 읽는 중 오류가 발생했습니다:', error);
+        console.error('Error reading configuration file:', error);
         return DEFAULT_CONFIG;
     }
 }
@@ -61,7 +61,7 @@ export async function saveConfig(config: SSHConfig): Promise<void> {
     try {
         await writeFile(getConfigFile(), JSON.stringify(config, null, 2), 'utf-8');
     } catch (error) {
-        console.error('설정 파일을 저장하는 중 오류가 발생했습니다:', error);
+        console.error('Error saving configuration file:', error);
         throw error;
     }
 }
@@ -69,7 +69,7 @@ export async function saveConfig(config: SSHConfig): Promise<void> {
 export async function addHost(host: SSHHost): Promise<void> {
     const config = await loadConfig();
 
-    // 중복 이름 체크
+    // Check for duplicate names
     const existingIndex = config.hosts.findIndex(h => h.name === host.name);
     if (existingIndex >= 0) {
         config.hosts[existingIndex] = host;

--- a/packages/cli/src/utils/display.ts
+++ b/packages/cli/src/utils/display.ts
@@ -1,0 +1,44 @@
+import chalk from 'chalk';
+import type { SSHHost } from '../types/ssh.js';
+
+/**
+ * Display host information in a formatted way
+ */
+export function displayHostInfo(host: SSHHost, title = 'Host information'): void {
+    console.log();
+    console.log(chalk.blue(`📋 ${title}:`));
+    console.log(`   ${chalk.cyan('Name:')} ${host.name}`);
+    console.log(`   ${chalk.cyan('Address:')} ${host.user}@${host.host}:${host.port}`);
+
+    if (host.keyPath) {
+        console.log(`   ${chalk.cyan('Key file:')} ${host.keyPath}`);
+    }
+
+    if (host.description) {
+        console.log(`   ${chalk.cyan('Description:')} ${host.description}`);
+    }
+
+    if (host.tags && host.tags.length > 0) {
+        console.log(`   ${chalk.cyan('Tags:')} ${host.tags.join(', ')}`);
+    }
+
+    if (host.autoCommands && host.autoCommands.length > 0) {
+        console.log(`   ${chalk.cyan('Auto commands:')} ${host.autoCommands.length} command(s)`);
+        host.autoCommands.forEach((cmd, index) => {
+            console.log(`     ${chalk.dim(`${index + 1}.`)} ${chalk.yellow(cmd)}`);
+        });
+    }
+
+    console.log();
+    console.log(chalk.blue('💡 To connect:'), chalk.gray(`simple-ssh connect ${host.name}`));
+}
+
+/**
+ * Create host selection choices for inquirer
+ */
+export function createHostChoices(hosts: SSHHost[]) {
+    return hosts.map(host => ({
+        name: `${chalk.cyan(host.name)} - ${host.user}@${host.host}:${host.port}${host.description ? ` (${host.description})` : ''}`,
+        value: host.name,
+    }));
+}

--- a/packages/cli/tests/unit/config.test.ts
+++ b/packages/cli/tests/unit/config.test.ts
@@ -19,8 +19,8 @@ describe('Config Management', () => {
         process.env.HOME = testConfigDir;
         process.env.USERPROFILE = testConfigDir; // For Windows compatibility
 
-        // 각 테스트마다 깨끗한 환경 보장
-        process.env.USER = 'testuser'; // 일관된 테스트 환경
+        // Ensure clean environment for each test
+        process.env.USER = 'testuser'; // Consistent test environment
     });
 
     afterEach(() => {
@@ -31,7 +31,7 @@ describe('Config Management', () => {
         process.env.HOME = originalConfigDir;
         process.env.USERPROFILE = originalConfigDir;
 
-        // USER 환경변수도 복원
+        // Restore USER environment variable
         if (originalConfigDir.includes('kangminsu')) {
             process.env.USER = 'kangminsu';
         }
@@ -43,7 +43,7 @@ describe('Config Management', () => {
 
             expect(config.hosts).toEqual([]);
             expect(config.defaultPort).toBe(22);
-            expect(typeof config.defaultUser).toBe('string'); // 사용자명은 환경에 따라 다름
+            expect(typeof config.defaultUser).toBe('string'); // Username varies by environment
         });
 
         it('should load existing config file', async () => {
@@ -111,7 +111,7 @@ describe('Config Management', () => {
             await addHost(host2);
 
             const config = await loadConfig();
-            // 같은 이름의 호스트는 하나만 있어야 함
+            // Only one host with the same name should exist
             const sameNameHosts = config.hosts.filter(h => h.name === 'same-name');
             expect(sameNameHosts).toHaveLength(1);
             expect(sameNameHosts[0]).toEqual(host2);
@@ -133,7 +133,7 @@ describe('Config Management', () => {
             expect(removed).toBe(true);
 
             const config = await loadConfig();
-            // 해당 이름의 호스트가 없어야 함
+            // Host with that name should not exist
             const removedHost = config.hosts.find(h => h.name === 'to-remove');
             expect(removedHost).toBeUndefined();
         });


### PR DESCRIPTION
Adds the ability to configure and execute commands automatically after establishing an SSH connection.

This feature enhances the CLI by allowing users to specify a set of commands to be run on the remote host immediately after connecting, streamlining common tasks and configurations.

Key changes include:

- Introduces prompts for configuring auto-run commands during host addition and editing.
- Stores auto-commands as an array of strings in the host configuration.
- Executes the configured commands upon connection, before presenting the user with an interactive shell.
- Displays the configured auto-commands before connection.
- Refactors host display and connection logic into separate utils for better organization.